### PR TITLE
Handle exceptions in plugins

### DIFF
--- a/example-package/pyproject.toml
+++ b/example-package/pyproject.toml
@@ -11,6 +11,7 @@ version = "0.1.0"
 [project.entry-points."example.group"]
 hello = "example.example:hello"
 42 = "example.example:hello"
+666 = "example.example:spanish_inquisition"
 
 [tool.setuptools]
 include-package-data = true

--- a/example-package/src/example/example.py
+++ b/example-package/src/example/example.py
@@ -18,4 +18,17 @@ def hello(raw: bytes) -> bytes:
     return raw[::-1]
 
 
+def spanish_inquisition(raw: bytes) -> bytes:
+    """
+    An example of a malfunctioning plugin, in this example an exception will
+    be raised.
+
+    :param raw: the input of the plugin, raw bytes which can be de-serialized.
+    :raises RuntimeError: always raises RuntimeError, for simulation of
+                          a malfunctioning plugin.
+    """
+    raise RuntimeError("Nobody expects the Spanish inquisition!")
+
+
 typed_plugin: Plugin = hello
+typed_malfunctioning_plugin: Plugin = spanish_inquisition

--- a/test/loader.cpp
+++ b/test/loader.cpp
@@ -168,7 +168,7 @@ execute_plugin(const std::string& group_name,
 
     } catch (py::error_already_set& e) {
       /* catch all python's exceptions */
-      std::cout << "Caught an exception from python, which is: " << e.what()
+      std::cerr << "Caught an exception from python, which is: " << e.what()
                 << std::endl;
       PyErr_Clear();
       return 1;


### PR DESCRIPTION
Added an integration test which verifies that C++ code can handle exceptions raised from the loaded entry-points.

Closes #11 